### PR TITLE
Don't hard-require numpy.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=files.txt
   skip: true  # [win]
   entry_points:
@@ -29,12 +29,13 @@ requirements:
     - setuptools
 
   run:
-    - numpy
     - pathlib  # [py2k]
     - python
     - six
 
 test:
+  requires:
+    - numpy
   imports:
     - pwkit
   commands:


### PR DESCRIPTION
Lots of parts, like the CLI tools, are orthogonal to numpy.