### PR TITLE
recipe/meta.yaml: fix redundant test.requires section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
     - pkenvtool = pwkit.environments:commandline
     - wrapout = pwkit.cli.wrapout:commandline
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
 
 requirements:
@@ -34,6 +34,7 @@ requirements:
 test:
   requires:
     - numpy
+    - pip
     - python {{ python_min }}
   imports:
     - pwkit
@@ -46,9 +47,6 @@ test:
     - pkcasascript --help
     - pkenvtool --help
     - wrapout echo hello world
-  requires:
-    - pip
-    - python {{ python_min }}
 
 about:
   home: https://github.com/pkgw/pwkit/


### PR DESCRIPTION
Should have looked at this before merging the no-arch Python update; oops.

No build number bump since the change is only in the test section, so the produced packages really really ought to be the same.